### PR TITLE
Setup foundations and basic implementations for CQRS

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@hono/node-server": "^1.13.2",
     "hono": "^4.6.5",
-    "pg": "^8.13.0"
+    "pg": "^8.13.0",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
@@ -24,6 +25,7 @@
     "@eslint/js": "^9.12.0",
     "@types/node": "^20.11.17",
     "@types/pg": "^8.11.10",
+    "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^2.1.2",
     "eslint": "^9.12.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   pg:
     specifier: ^8.13.0
     version: 8.13.0
+  uuid:
+    specifier: ^10.0.0
+    version: 10.0.0
 
 devDependencies:
   "@commitlint/cli":
@@ -31,6 +34,9 @@ devDependencies:
   "@types/pg":
     specifier: ^8.11.10
     version: 8.11.10
+  "@types/uuid":
+    specifier: ^10.0.0
+    version: 10.0.0
   "@vitest/coverage-v8":
     specifier: ^2.1.2
     version: 2.1.3(vitest@2.1.3)
@@ -1393,6 +1399,13 @@ packages:
       "@types/node": 20.16.13
       pg-protocol: 1.7.0
       pg-types: 4.0.2
+    dev: true
+
+  /@types/uuid@10.0.0:
+    resolution:
+      {
+        integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==,
+      }
     dev: true
 
   /@typescript-eslint/eslint-plugin@8.10.0(@typescript-eslint/parser@8.10.0)(eslint@9.13.0)(typescript@5.6.3):
@@ -4279,6 +4292,14 @@ packages:
     dependencies:
       punycode: 2.3.1
     dev: true
+
+  /uuid@10.0.0:
+    resolution:
+      {
+        integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
+      }
+    hasBin: true
+    dev: false
 
   /vite-node@2.1.3(@types/node@20.16.13):
     resolution:

--- a/src/app/__tests__/app.unit.test.ts
+++ b/src/app/__tests__/app.unit.test.ts
@@ -69,11 +69,9 @@ describe("getApp", () => {
 
   it("should delete a comment by id", async () => {
     const id = "comment1";
-    mockDataStore.deleteCommentById.mockResolvedValue(true);
 
-    const result = await app.deleteCommentById(id);
+    await app.deleteCommentById(id);
 
     expect(mockDataStore.deleteCommentById).toHaveBeenCalledWith({ id });
-    expect(result).toBe(true);
   });
 });

--- a/src/app/__tests__/app.unit.test.ts
+++ b/src/app/__tests__/app.unit.test.ts
@@ -9,7 +9,20 @@ describe("getApp", () => {
     deleteCommentById: vi.fn(),
   };
 
-  const app = getApp({ dataStore: mockDataStore });
+  const mockEventBroker = {
+    publish: vi.fn(),
+    subscribe: vi.fn(),
+  };
+
+  const mockRandomId = {
+    generate: vi.fn(),
+  };
+
+  const app = getApp({
+    dataStore: mockDataStore,
+    eventBroker: mockEventBroker,
+    randomId: mockRandomId,
+  });
 
   it("should get comments for a host", async () => {
     const hostId = "host1";

--- a/src/app/commands/__tests__/create-comment.unit.test.ts
+++ b/src/app/commands/__tests__/create-comment.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import type { DataStore } from "../../driven-ports/data-store.js";
+import type { Comment } from "../../domain/entities/comment.js";
+import { commandCreateComment } from "../create-comment/index.js";
+
+describe("commandCreateComment", () => {
+  it("should save a comment and return it", async () => {
+    const mockDataStore: DataStore = {
+      saveCommentByHostId: vi.fn().mockResolvedValue({
+        id: "1",
+        content: "This is a comment",
+        hostId: "host123",
+      } as Comment),
+      deleteCommentById: vi.fn(),
+      getAllCommentsByHostId: vi.fn(),
+      updateCommentById: vi.fn(),
+    };
+
+    const createComment = commandCreateComment(mockDataStore);
+
+    const input = {
+      hostId: "host123",
+      content: "This is a comment",
+    };
+
+    const result = await createComment(input);
+
+    expect(mockDataStore.saveCommentByHostId).toHaveBeenCalledWith(input);
+    expect(result).toEqual({
+      id: "1",
+      hostId: "host123",
+      content: "This is a comment",
+    });
+  });
+});

--- a/src/app/commands/__tests__/delete-comment.unit.test.ts
+++ b/src/app/commands/__tests__/delete-comment.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import type { DataStore } from "../../driven-ports/data-store.js";
+import { commandDeleteComment } from "../delete-comment/index.js";
+
+describe("commandDeleteComment", () => {
+  it("should delete a comment by id", async () => {
+    const mockDataStore: DataStore = {
+      deleteCommentById: vi.fn().mockResolvedValue(undefined),
+      getAllCommentsByHostId: vi.fn(),
+      saveCommentByHostId: vi.fn(),
+      updateCommentById: vi.fn(),
+    };
+
+    const deleteComment = commandDeleteComment(mockDataStore);
+
+    const input = {
+      id: "1",
+    };
+
+    await deleteComment(input);
+
+    expect(mockDataStore.deleteCommentById).toHaveBeenCalledWith(input);
+  });
+});

--- a/src/app/commands/__tests__/update-comment.unit.test.ts
+++ b/src/app/commands/__tests__/update-comment.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Comment } from "../../domain/entities/comment.js";
+import type { DataStore } from "../../driven-ports/data-store.js";
+import { commandUpdateComment } from "../update-comment/index.js";
+
+describe("commandUpdateComment", () => {
+  it("should update a comment and return it", async () => {
+    const mockDataStore: DataStore = {
+      updateCommentById: vi.fn().mockResolvedValue({
+        id: "1",
+        content: "Updated content",
+      } as Comment),
+      deleteCommentById: vi.fn(),
+      getAllCommentsByHostId: vi.fn(),
+      saveCommentByHostId: vi.fn(),
+    };
+
+    const updateComment = commandUpdateComment(mockDataStore);
+
+    const input = {
+      id: "1",
+      content: "Updated content",
+    };
+
+    const result = await updateComment(input);
+
+    expect(mockDataStore.updateCommentById).toHaveBeenCalledWith(input);
+    expect(result).toEqual({
+      id: "1",
+      content: "Updated content",
+    });
+  });
+});

--- a/src/app/commands/create-comment/index.ts
+++ b/src/app/commands/create-comment/index.ts
@@ -1,0 +1,22 @@
+import type { Comment } from "../../domain/entities/comment.js";
+import type { DataStore } from "../../driven-ports/data-store.js";
+
+type CommandCreateComment = (
+  dataStore: DataStore,
+) => ({
+  hostId,
+  content,
+}: {
+  hostId: Comment["hostId"];
+  content: Comment["content"];
+}) => Promise<Comment>;
+
+const commandCreateComment: CommandCreateComment = (dataStore) => {
+  return async ({ hostId, content }) => {
+    const comment = await dataStore.saveCommentByHostId({ hostId, content });
+
+    return comment;
+  };
+};
+
+export { commandCreateComment };

--- a/src/app/commands/delete-comment/index.ts
+++ b/src/app/commands/delete-comment/index.ts
@@ -1,0 +1,14 @@
+import type { Comment } from "../../domain/entities/comment.js";
+import type { DataStore } from "../../driven-ports/data-store.js";
+
+type CommandDeleteComment = (
+  dataStore: DataStore,
+) => ({ id }: { id: Comment["id"] }) => Promise<void>;
+
+const commandDeleteComment: CommandDeleteComment = (dataStore) => {
+  return async ({ id }) => {
+    await dataStore.deleteCommentById({ id });
+  };
+};
+
+export { commandDeleteComment };

--- a/src/app/commands/update-comment/index.ts
+++ b/src/app/commands/update-comment/index.ts
@@ -1,0 +1,22 @@
+import type { Comment } from "../../domain/entities/comment.js";
+import type { DataStore } from "../../driven-ports/data-store.js";
+
+type CommandUpdateComment = (
+  dataStore: DataStore,
+) => ({
+  id,
+  content,
+}: {
+  id: Comment["id"];
+  content: Comment["content"];
+}) => Promise<Comment>;
+
+const commandUpdateComment: CommandUpdateComment = (dataStore) => {
+  return async ({ id, content }) => {
+    const comment = await dataStore.updateCommentById({ id, content });
+
+    return comment;
+  };
+};
+
+export { commandUpdateComment };

--- a/src/app/driven-ports/__tests__/event-broker.test-runner.ts
+++ b/src/app/driven-ports/__tests__/event-broker.test-runner.ts
@@ -1,0 +1,40 @@
+// event-broker.test.ts
+import { describe, expect, it, vi } from "vitest";
+import type { EventBroker, CloudEvent } from "../event-broker.js";
+
+const mockEvent: CloudEvent = {
+  specversion: "1.0",
+  type: "com.example.someevent",
+  source: "/mycontext",
+  subject: "123",
+  id: "A234-1234-1234",
+  time: "2020-08-24T14:15:22Z",
+  datacontenttype: "application/json",
+  data: { key: "value" },
+};
+
+const runEventBrokerTests = (eventBroker: EventBroker) => {
+  describe("EventBroker Port Tests", () => {
+    it("should publish an event", () => {
+      const publishSpy = vi.fn();
+      eventBroker.publish = publishSpy;
+
+      eventBroker.publish({ event: mockEvent });
+      expect(publishSpy).toHaveBeenCalledWith({ event: mockEvent });
+    });
+
+    it("should subscribe to an event and handle it", () => {
+      const handlerSpy = vi.fn();
+      eventBroker.subscribe({
+        type: "com.example.someevent",
+        handler: handlerSpy,
+      });
+
+      // Simulate an event being published
+      handlerSpy(mockEvent);
+      expect(handlerSpy).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+};
+
+export { runEventBrokerTests };

--- a/src/app/driven-ports/event-broker.ts
+++ b/src/app/driven-ports/event-broker.ts
@@ -1,0 +1,27 @@
+type CloudEvent = {
+  specversion: string;
+  type: string;
+  source: string;
+  subject: string;
+  id: string;
+  time: string;
+  datacontenttype: string;
+  data: object;
+};
+
+type PublishEvent = ({ event }: { event: CloudEvent }) => void;
+
+type SubscribeToEvent = ({
+  type,
+  handler,
+}: {
+  type: string;
+  handler: (event: CloudEvent) => void;
+}) => void;
+
+type EventBroker = {
+  publish: PublishEvent;
+  subscribe: SubscribeToEvent;
+};
+
+export type { CloudEvent, EventBroker, PublishEvent, SubscribeToEvent };

--- a/src/app/driven-ports/random-id.ts
+++ b/src/app/driven-ports/random-id.ts
@@ -1,0 +1,5 @@
+type RandomId = {
+  generate: () => string;
+};
+
+export type { RandomId };

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,15 +1,43 @@
 import type { DataStore } from "./driven-ports/data-store.js";
 import type { App } from "./domain/entities/app.js";
+import type { EventBroker } from "./driven-ports/event-broker.js";
+import type { RandomId } from "./driven-ports/random-id.js";
 
-type GetApp = ({ dataStore }: { dataStore: DataStore }) => App;
+type GetApp = ({
+  dataStore,
+  eventBroker,
+  randomId,
+}: {
+  dataStore: DataStore;
+  eventBroker: EventBroker;
+  randomId: RandomId;
+}) => App;
 
-const getApp: GetApp = ({ dataStore }) => {
+const getApp: GetApp = ({ dataStore, eventBroker, randomId }) => {
   return {
     getCommentsForHost: async (hostId) => {
       return await dataStore.getAllCommentsByHostId({ hostId });
     },
     createCommentForHost: async (hostId, content) => {
-      return await dataStore.saveCommentByHostId({ hostId, content });
+      const savedComment = await dataStore.saveCommentByHostId({
+        hostId,
+        content,
+      });
+
+      eventBroker.publish({
+        event: {
+          specversion: "1.0",
+          type: "comment.created",
+          source: "app",
+          datacontenttype: "application/json",
+          data: savedComment,
+          id: randomId.generate(),
+          subject: hostId,
+          time: new Date().toISOString(),
+        },
+      });
+
+      return savedComment;
     },
     updateCommentById: async (id, content) => {
       return await dataStore.updateCommentById({ id, content });

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -5,6 +5,7 @@ import type { RandomId } from "./driven-ports/random-id.js";
 import { commandCreateComment } from "./commands/create-comment/index.js";
 import { commandUpdateComment } from "./commands/update-comment/index.js";
 import { commandDeleteComment } from "./commands/delete-comment/index.js";
+import { queryGetCommentsForHost } from "./queries/get-comments-for-host/index.js";
 
 type GetApp = ({
   dataStore,
@@ -19,7 +20,13 @@ type GetApp = ({
 const getApp: GetApp = ({ dataStore, eventBroker, randomId }) => {
   return {
     getCommentsForHost: async (hostId) => {
-      return await dataStore.getAllCommentsByHostId({ hostId });
+      const query = queryGetCommentsForHost(dataStore);
+
+      const comments = await query({
+        hostId,
+      });
+
+      return comments;
     },
     createCommentForHost: async (hostId, content) => {
       const command = commandCreateComment(dataStore);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -4,6 +4,7 @@ import type { EventBroker } from "./driven-ports/event-broker.js";
 import type { RandomId } from "./driven-ports/random-id.js";
 import { commandCreateComment } from "./commands/create-comment/index.js";
 import { commandUpdateComment } from "./commands/update-comment/index.js";
+import { commandDeleteComment } from "./commands/delete-comment/index.js";
 
 type GetApp = ({
   dataStore,
@@ -67,7 +68,24 @@ const getApp: GetApp = ({ dataStore, eventBroker, randomId }) => {
       return updatedComment;
     },
     deleteCommentById: async (id) => {
-      return await dataStore.deleteCommentById({ id });
+      const command = commandDeleteComment(dataStore);
+
+      await command({
+        id,
+      });
+
+      eventBroker.publish({
+        event: {
+          specversion: "1.0",
+          type: "comment.deleted",
+          source: "app",
+          datacontenttype: "application/json",
+          data: { id },
+          id: randomId.generate(),
+          subject: id,
+          time: new Date().toISOString(),
+        },
+      });
     },
   };
 };

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,6 +2,7 @@ import type { DataStore } from "./driven-ports/data-store.js";
 import type { App } from "./domain/entities/app.js";
 import type { EventBroker } from "./driven-ports/event-broker.js";
 import type { RandomId } from "./driven-ports/random-id.js";
+import { commandCreateComment } from "./commands/create-comment/index.js";
 
 type GetApp = ({
   dataStore,
@@ -19,7 +20,9 @@ const getApp: GetApp = ({ dataStore, eventBroker, randomId }) => {
       return await dataStore.getAllCommentsByHostId({ hostId });
     },
     createCommentForHost: async (hostId, content) => {
-      const savedComment = await dataStore.saveCommentByHostId({
+      const command = commandCreateComment(dataStore);
+
+      const savedComment = await command({
         hostId,
         content,
       });

--- a/src/app/queries/get-comments-for-host/index.ts
+++ b/src/app/queries/get-comments-for-host/index.ts
@@ -1,0 +1,16 @@
+import type { Comment } from "../../domain/entities/comment.js";
+import type { DataStore } from "../../driven-ports/data-store.js";
+
+type QueryGetCommentsForHost = (
+  dataStore: DataStore,
+) => ({ hostId }: { hostId: Comment["hostId"] }) => Promise<Comment[]>;
+
+const queryGetCommentsForHost: QueryGetCommentsForHost = (dataStore) => {
+  return async ({ hostId }) => {
+    const comment = await dataStore.getAllCommentsByHostId({ hostId });
+
+    return comment;
+  };
+};
+
+export { queryGetCommentsForHost };

--- a/src/driven-adapters/data-store/postgres/index.ts
+++ b/src/driven-adapters/data-store/postgres/index.ts
@@ -1,5 +1,6 @@
 import type { Config } from "../../../app/driven-ports/config.js";
 import type { DataStore } from "../../../app/driven-ports/data-store.js";
+import type { RandomId } from "../../../app/driven-ports/random-id.js";
 import type { SecretStore } from "../../../app/driven-ports/secret-store.js";
 import { migrate } from "./migrate.js";
 import { getPgPool } from "./pool.js";
@@ -13,14 +14,17 @@ import {
 type GetDataStorePostgres = ({
   config,
   secretStore,
+  randomId,
 }: {
   config: Config["dataStore"];
   secretStore: SecretStore;
+  randomId: RandomId;
 }) => Promise<DataStore>;
 
 const getDataStorePostgres: GetDataStorePostgres = async ({
   config,
   secretStore,
+  randomId,
 }) => {
   const pgPool = getPgPool({ config, secretStore });
 
@@ -41,8 +45,9 @@ const getDataStorePostgres: GetDataStorePostgres = async ({
     },
     saveCommentByHostId: async ({ hostId, content }) => {
       try {
+        const id = randomId.generate();
         const result = await pgPool.query(
-          saveCommentByHostIdQuery({ hostId, content }),
+          saveCommentByHostIdQuery({ id, hostId, content }),
         );
 
         return result.rows[0];

--- a/src/driven-adapters/data-store/postgres/queries.ts
+++ b/src/driven-adapters/data-store/postgres/queries.ts
@@ -8,9 +8,11 @@ type GetAllCommentsByHostIdQuery = ({
   hostId: Comment["hostId"];
 }) => QueryConfig;
 type SaveCommentByHostIdQuery = ({
+  id,
   hostId,
   content,
 }: {
+  id: Comment["id"];
   hostId: Comment["hostId"];
   content: Comment["content"];
 }) => QueryConfig;
@@ -51,17 +53,18 @@ const getAllCommentsByHostIdQuery: GetAllCommentsByHostIdQuery = ({
 };
 
 const saveCommentByHostIdQuery: SaveCommentByHostIdQuery = ({
+  id,
   hostId,
   content,
 }) => {
   return {
     name: "save-comment-by-host-id",
     text: `
-        INSERT INTO comments (content, hostId)
-        VALUES ($1, $2)
+        INSERT INTO comments (id, content, hostId, createdAt, updatedAt)
+        VALUES ($1, $2, $3, NOW(), NOW())
         RETURNING *;
         `,
-    values: [content, hostId],
+    values: [id, content, hostId],
   };
 };
 
@@ -70,7 +73,7 @@ const updateCommentByIdQuery: UpdateCommentByIdQuery = ({ id, content }) => {
     name: "update-comment-by-id",
     text: `
         UPDATE comments
-        SET content = $1
+        SET content = $1, updatedAt = NOW()
         WHERE id = $2
         RETURNING *;
         `,

--- a/src/driven-adapters/event-broker/__tests__/in-memory.unit.test.ts
+++ b/src/driven-adapters/event-broker/__tests__/in-memory.unit.test.ts
@@ -1,0 +1,8 @@
+import { describe } from "vitest";
+import { getEventBrokerInMemory } from "../in-memory.js";
+import { runEventBrokerTests } from "../../../app/driven-ports/__tests__/event-broker.test-runner.js";
+
+describe("EventBrokerInMemory", () => {
+  const eventBroker = getEventBrokerInMemory();
+  runEventBrokerTests(eventBroker);
+});

--- a/src/driven-adapters/event-broker/in-memory.ts
+++ b/src/driven-adapters/event-broker/in-memory.ts
@@ -1,0 +1,19 @@
+import EventEmitter from "events";
+import type { EventBroker } from "../../app/driven-ports/event-broker.js";
+
+type GetEventBrokerInMemory = () => EventBroker;
+
+const getEventBrokerInMemory: GetEventBrokerInMemory = () => {
+  const eventEmitter = new EventEmitter();
+
+  return {
+    publish: ({ event }) => {
+      eventEmitter.emit(event.type, event);
+    },
+    subscribe: ({ type, handler }) => {
+      eventEmitter.on(type, handler);
+    },
+  };
+};
+
+export { getEventBrokerInMemory };

--- a/src/driven-adapters/random-id/uuid/index.ts
+++ b/src/driven-adapters/random-id/uuid/index.ts
@@ -1,0 +1,12 @@
+import { v4 as uuidv4 } from "uuid";
+import type { RandomId } from "../../../app/driven-ports/random-id.js";
+
+type GetRandomIdUuid = () => RandomId;
+
+const getRandomIdUuid: GetRandomIdUuid = () => {
+  return {
+    generate: () => uuidv4(),
+  };
+};
+
+export { getRandomIdUuid };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,23 @@
 import { getApp } from "./app/index.js";
 import { getConfigStaticEnv } from "./driven-adapters/config/static-env/index.js";
 import { getDataStorePostgres } from "./driven-adapters/data-store/postgres/index.js";
+import { getEventBrokerInMemory } from "./driven-adapters/event-broker/in-memory.js";
+import { getRandomIdUuid } from "./driven-adapters/random-id/uuid/index.js";
 import { getSecretStoreEnv } from "./driven-adapters/secrets/env/index.js";
 import { getHttpHono } from "./driver-adapters/http/hono/index.js";
 
 const config = getConfigStaticEnv();
 const secretStore = getSecretStoreEnv();
+const eventBroker = getEventBrokerInMemory();
+const randomId = getRandomIdUuid();
 
 const dataStore = await getDataStorePostgres({
   config: config.dataStore,
   secretStore,
+  randomId,
 });
 
-const app = getApp({ dataStore });
+const app = getApp({ dataStore, eventBroker, randomId });
 
 const hono = getHttpHono({ app, config: config.http });
 


### PR DESCRIPTION
This PR aims to set up the foundations for the full CQRS pattern.

- Create ports and adapters for `eventBroker` and `randomId`
- Convert all operations into commands and queries
- Use these commands and queries to run operations in the app

An explanation of the Command-Query Responsibility Segregation pattern can be found [here](https://www.geeksforgeeks.org/cqrs-command-query-responsibility-segregation/)

There is no event sourcing yet, but it's something I plan to add. As of now, the app only publishes events but there are no subscribers. Will be added in a future PR.

There also is quite a bit of missing validation, but this will be tackled later as well.

