### PR TITLE
Implement caching with event-based invalidation

### DIFF
--- a/src/app/__tests__/app.unit.test.ts
+++ b/src/app/__tests__/app.unit.test.ts
@@ -18,10 +18,18 @@ describe("getApp", () => {
     generate: vi.fn(),
   };
 
+  const mockCacheStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  };
+
   const app = getApp({
     dataStore: mockDataStore,
     eventBroker: mockEventBroker,
     randomId: mockRandomId,
+    cacheStore: mockCacheStore,
   });
 
   it("should get comments for a host", async () => {
@@ -69,7 +77,13 @@ describe("getApp", () => {
 
   it("should delete a comment by id", async () => {
     const id = "comment1";
+    const content = "Nice place!";
 
+    const savedComment = { id, content };
+    mockDataStore.saveCommentByHostId.mockResolvedValue(savedComment);
+    await app.createCommentForHost({ hostId: "host1", content });
+
+    mockDataStore.deleteCommentById.mockResolvedValue(savedComment);
     await app.deleteCommentById({ id });
 
     expect(mockDataStore.deleteCommentById).toHaveBeenCalledWith({ id });

--- a/src/app/commands/__tests__/create-comment.unit.test.ts
+++ b/src/app/commands/__tests__/create-comment.unit.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DataStore } from "../../driven-ports/data-store.js";
-import type { Comment } from "../../domain/entities/comment.js";
 import { commandCreateComment } from "../create-comment/index.js";
 
 describe("commandCreateComment", () => {
@@ -9,8 +8,10 @@ describe("commandCreateComment", () => {
       saveCommentByHostId: vi.fn().mockResolvedValue({
         id: "1",
         content: "This is a comment",
-        hostId: "host123",
-      } as Comment),
+        hostid: "host123",
+        createdat: new Date().toISOString(),
+        updatedat: new Date().toISOString(),
+      }),
       deleteCommentById: vi.fn(),
       getAllCommentsByHostId: vi.fn(),
       updateCommentById: vi.fn(),
@@ -30,6 +31,8 @@ describe("commandCreateComment", () => {
       id: "1",
       hostId: "host123",
       content: "This is a comment",
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
     });
   });
 });

--- a/src/app/commands/__tests__/delete-comment.unit.test.ts
+++ b/src/app/commands/__tests__/delete-comment.unit.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DataStore } from "../../driven-ports/data-store.js";
 import { commandDeleteComment } from "../delete-comment/index.js";
+import type { Comment } from "../../domain/entities/comment.js";
 
 describe("commandDeleteComment", () => {
   it("should delete a comment by id", async () => {
+    const mockComment: Comment = {
+      id: "1",
+      content: "Test comment",
+      hostId: "host1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
     const mockDataStore: DataStore = {
-      deleteCommentById: vi.fn().mockResolvedValue(undefined),
+      deleteCommentById: vi.fn().mockResolvedValue({
+        id: mockComment.id,
+        content: mockComment.content,
+        hostid: mockComment.hostId,
+        createdat: mockComment.createdAt,
+        updatedat: mockComment.updatedAt,
+      }),
       getAllCommentsByHostId: vi.fn(),
       saveCommentByHostId: vi.fn(),
       updateCommentById: vi.fn(),
@@ -17,8 +32,9 @@ describe("commandDeleteComment", () => {
       id: "1",
     };
 
-    await deleteComment(input);
+    const result = await deleteComment(input);
 
     expect(mockDataStore.deleteCommentById).toHaveBeenCalledWith(input);
+    expect(result).toEqual(mockComment);
   });
 });

--- a/src/app/commands/create-comment/index.ts
+++ b/src/app/commands/create-comment/index.ts
@@ -13,7 +13,18 @@ type CommandCreateComment = (
 
 const commandCreateComment: CommandCreateComment = (dataStore) => {
   return async ({ hostId, content }) => {
-    const comment = await dataStore.saveCommentByHostId({ hostId, content });
+    const savedComment = await dataStore.saveCommentByHostId({
+      hostId,
+      content,
+    });
+
+    const comment: Comment = {
+      id: savedComment.id,
+      content: savedComment.content,
+      hostId: savedComment.hostid,
+      createdAt: savedComment.createdat,
+      updatedAt: savedComment.updatedat,
+    };
 
     return comment;
   };

--- a/src/app/commands/delete-comment/index.ts
+++ b/src/app/commands/delete-comment/index.ts
@@ -3,11 +3,21 @@ import type { DataStore } from "../../driven-ports/data-store.js";
 
 type CommandDeleteComment = (
   dataStore: DataStore,
-) => ({ id }: { id: Comment["id"] }) => Promise<void>;
+) => ({ id }: { id: Comment["id"] }) => Promise<Comment>;
 
 const commandDeleteComment: CommandDeleteComment = (dataStore) => {
   return async ({ id }) => {
-    await dataStore.deleteCommentById({ id });
+    const deletedComment = await dataStore.deleteCommentById({ id });
+
+    const comment: Comment = {
+      id: deletedComment.id,
+      content: deletedComment.content,
+      hostId: deletedComment.hostid,
+      createdAt: deletedComment.createdat,
+      updatedAt: deletedComment.updatedat,
+    };
+
+    return comment;
   };
 };
 

--- a/src/app/commands/update-comment/index.ts
+++ b/src/app/commands/update-comment/index.ts
@@ -13,7 +13,15 @@ type CommandUpdateComment = (
 
 const commandUpdateComment: CommandUpdateComment = (dataStore) => {
   return async ({ id, content }) => {
-    const comment = await dataStore.updateCommentById({ id, content });
+    const updatedComment = await dataStore.updateCommentById({ id, content });
+
+    const comment: Comment = {
+      id: updatedComment.id,
+      content: updatedComment.content,
+      hostId: updatedComment.hostid,
+      createdAt: updatedComment.createdat,
+      updatedAt: updatedComment.updatedat,
+    };
 
     return comment;
   };

--- a/src/app/domain/helpers/events/comment-deleted.ts
+++ b/src/app/domain/helpers/events/comment-deleted.ts
@@ -3,19 +3,19 @@ import type { RandomId } from "../../../driven-ports/random-id.js";
 import type { Comment } from "../../entities/comment.js";
 
 type ToCommentDeletedEvent = ({
-  deletedCommentId,
+  deletedComment,
   subject,
   source,
   randomId,
 }: {
-  deletedCommentId: Comment["id"];
+  deletedComment: Comment;
   subject: string;
   source: string;
   randomId: RandomId;
 }) => CloudEvent;
 
 const toCommentDeletedEvent: ToCommentDeletedEvent = ({
-  deletedCommentId,
+  deletedComment,
   subject,
   source,
   randomId,
@@ -25,7 +25,7 @@ const toCommentDeletedEvent: ToCommentDeletedEvent = ({
     type: "kommentar.comment.deleted",
     source,
     datacontenttype: "application/json",
-    data: { id: deletedCommentId },
+    data: deletedComment,
     id: randomId.generate(),
     subject,
     time: new Date().toISOString(),

--- a/src/app/driven-ports/__tests__/cache-store.unit.test-runner.ts
+++ b/src/app/driven-ports/__tests__/cache-store.unit.test-runner.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CacheStore } from "../cache-store.js";
+
+const mockKey = "testKey";
+const mockValue = "testValue";
+
+const runCacheStoreTests = (cacheStore: CacheStore) => {
+  describe("CacheStore Port Tests", () => {
+    beforeEach(() => {
+      cacheStore.clear();
+    });
+
+    it("should set and get a value by key", () => {
+      cacheStore.set(mockKey, mockValue);
+      const value = cacheStore.get(mockKey);
+      expect(value).toBe(mockValue);
+    });
+
+    it("should return null for a non-existent key", () => {
+      const value = cacheStore.get("nonExistentKey");
+      expect(value).toBeUndefined();
+    });
+
+    it("should remove a value by key", () => {
+      cacheStore.set(mockKey, mockValue);
+      cacheStore.remove(mockKey);
+      const value = cacheStore.get(mockKey);
+      expect(value).toBeUndefined();
+    });
+
+    it("should clear all values", () => {
+      cacheStore.set(mockKey, mockValue);
+      cacheStore.clear();
+      const value = cacheStore.get(mockKey);
+      expect(value).toBeUndefined();
+    });
+  });
+};
+
+export { runCacheStoreTests };

--- a/src/app/driven-ports/__tests__/data-store.unit.test-runner.ts
+++ b/src/app/driven-ports/__tests__/data-store.unit.test-runner.ts
@@ -46,7 +46,7 @@ const runDataStoreTests = (dataStore: DataStore) => {
 
       comments.map((comment, index) => {
         expect(comment.id).toBeTypeOf("string");
-        expect(comment.hostId).toBe(mockComments[index].hostId);
+        expect(comment.hostid).toBe(mockComments[index].hostId);
         expect(comment.content).toBe(mockComments[index].content);
       });
     });
@@ -58,7 +58,7 @@ const runDataStoreTests = (dataStore: DataStore) => {
       });
 
       expect(savedComment.id).toBeTypeOf("string");
-      expect(savedComment.hostId).toBe(mockComment.hostId);
+      expect(savedComment.hostid).toBe(mockComment.hostId);
       expect(savedComment.content).toBe(mockComment.content);
     });
 
@@ -74,14 +74,23 @@ const runDataStoreTests = (dataStore: DataStore) => {
       });
 
       expect(updatedComment.id).toBe(commentToUpdate.id);
-      expect(updatedComment.hostId).toBe(commentToUpdate.hostId);
+      expect(updatedComment.hostid).toBe(commentToUpdate.hostid);
       expect(updatedComment.content).toBe("Updated comment");
     });
 
     it("should delete a comment by identifier", async () => {
-      await expect(
-        dataStore.deleteCommentById({ id: "3" }),
-      ).resolves.toBeUndefined();
+      const commentToDelete = await dataStore.saveCommentByHostId({
+        hostId: "host2",
+        content: "New comment to delete",
+      });
+
+      const deletedComment = await dataStore.deleteCommentById({
+        id: commentToDelete.id,
+      });
+
+      expect(deletedComment.id).toBe(commentToDelete.id);
+      expect(deletedComment.hostid).toBe(commentToDelete.hostid);
+      expect(deletedComment.content).toBe(commentToDelete.content);
     });
   });
 };

--- a/src/app/driven-ports/cache-store.ts
+++ b/src/app/driven-ports/cache-store.ts
@@ -1,5 +1,5 @@
 type CacheStore = {
-  get: (key: string) => unknown | undefined;
+  get: (key: string) => unknown | unknown[] | undefined;
   set: (key: string, value: unknown) => void;
   remove: (key: string) => void;
   clear: () => void;

--- a/src/app/driven-ports/cache-store.ts
+++ b/src/app/driven-ports/cache-store.ts
@@ -1,0 +1,8 @@
+type CacheStore = {
+  get: (key: string) => unknown | undefined;
+  set: (key: string, value: unknown) => void;
+  remove: (key: string) => void;
+  clear: () => void;
+};
+
+export type { CacheStore };

--- a/src/app/driven-ports/data-store.ts
+++ b/src/app/driven-ports/data-store.ts
@@ -1,5 +1,13 @@
 import type { Comment } from "../domain/entities/comment.js";
 
+type StoredComment = {
+  id: Comment["id"];
+  content: Comment["content"];
+  hostid: Comment["hostId"];
+  createdat: Comment["createdAt"];
+  updatedat: Comment["updatedAt"];
+};
+
 type DataStore = {
   /**
    * Get all comments by host identifier
@@ -11,7 +19,7 @@ type DataStore = {
     hostId,
   }: {
     hostId: Comment["hostId"];
-  }) => Promise<Comment[]>;
+  }) => Promise<StoredComment[]>;
 
   /**
    * Save a new comment by host identifier
@@ -26,7 +34,7 @@ type DataStore = {
   }: {
     hostId: Comment["hostId"];
     content: Comment["content"];
-  }) => Promise<Comment>;
+  }) => Promise<StoredComment>;
 
   /**
    * Update a comment by identifier
@@ -41,14 +49,14 @@ type DataStore = {
   }: {
     id: Comment["id"];
     content: Comment["content"];
-  }) => Promise<Comment>;
+  }) => Promise<StoredComment>;
 
   /**
    * Delete a comment by identifier
    *
    * @param id - Unique identifier of the comment
    */
-  deleteCommentById: ({ id }: { id: Comment["id"] }) => Promise<void>;
+  deleteCommentById: ({ id }: { id: Comment["id"] }) => Promise<StoredComment>;
 };
 
-export type { DataStore };
+export type { DataStore, StoredComment };

--- a/src/app/policies/__tests__/comment-created.unit.test.ts
+++ b/src/app/policies/__tests__/comment-created.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type { EventBroker } from "../../driven-ports/event-broker.js";
+import type { CacheStore } from "../../driven-ports/cache-store.js";
+import { wheneverCommentCreatedInvalidateCache } from "../whenever-comment-created-invalidate-cache.js";
+import type { Comment } from "../../domain/entities/comment.js";
+
+describe("wheneverCommentCreatedInvalidateCache", () => {
+  it("should add a new comment to the cache when there are no cached comments", () => {
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentCreatedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const newComment: Comment = {
+      id: "1",
+      content: "New comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: newComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).toHaveBeenCalledWith("comment-1", [newComment]);
+  });
+
+  it("should add a new comment to the existing cached comments", () => {
+    const existingComments: Comment[] = [
+      {
+        id: "1",
+        content: "Existing comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+    ];
+
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(existingComments),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentCreatedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const newComment: Comment = {
+      id: "2",
+      content: "New comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: newComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).toHaveBeenCalledWith("comment-1", [
+      ...existingComments,
+      newComment,
+    ]);
+  });
+});

--- a/src/app/policies/__tests__/comment-deleted.unit.test.ts
+++ b/src/app/policies/__tests__/comment-deleted.unit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type { EventBroker } from "../../driven-ports/event-broker.js";
+import type { CacheStore } from "../../driven-ports/cache-store.js";
+import { wheneverCommentDeletedInvalidateCache } from "../whenever-comment-deleted-invalidate-cache.js";
+import type { Comment } from "../../domain/entities/comment.js";
+
+describe("wheneverCommentDeletedInvalidateCache", () => {
+  it("should do nothing when there are no cached comments", () => {
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentDeletedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const deletedComment: Comment = {
+      id: "1",
+      content: "Deleted comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: deletedComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).not.toHaveBeenCalled();
+  });
+
+  it("should remove the deleted comment from the existing cached comments", () => {
+    const existingComments: Comment[] = [
+      {
+        id: "1",
+        content: "Existing comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+      {
+        id: "2",
+        content: "Another comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+    ];
+
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(existingComments),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentDeletedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const deletedComment: Comment = {
+      id: "1",
+      content: "Deleted comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: deletedComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).toHaveBeenCalledWith("1", [
+      {
+        id: "2",
+        content: "Another comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+    ]);
+  });
+});

--- a/src/app/policies/__tests__/comment-updated.unit.test.ts
+++ b/src/app/policies/__tests__/comment-updated.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type { EventBroker } from "../../driven-ports/event-broker.js";
+import type { CacheStore } from "../../driven-ports/cache-store.js";
+import { wheneverCommentUpdatedInvalidateCache } from "../whenever-comment-updated-invalidate-cache.js";
+import type { Comment } from "../../domain/entities/comment.js";
+
+describe("wheneverCommentUpdatedInvalidateCache", () => {
+  it("should add the updated comment to the cache when there are no cached comments", () => {
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentUpdatedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const updatedComment: Comment = {
+      id: "1",
+      content: "Updated comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: updatedComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).toHaveBeenCalledWith("1", [updatedComment]);
+  });
+
+  it("should update the existing cached comment", () => {
+    const existingComments: Comment[] = [
+      {
+        id: "1",
+        content: "Existing comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+      {
+        id: "2",
+        content: "Another comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+    ];
+
+    const mockEventBroker: EventBroker = {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    };
+    const mockCacheStore: CacheStore = {
+      get: vi.fn().mockReturnValue(existingComments),
+      set: vi.fn(),
+      clear: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    wheneverCommentUpdatedInvalidateCache({
+      eventBroker: mockEventBroker,
+      cacheStore: mockCacheStore,
+    });
+
+    const eventHandler = (mockEventBroker.subscribe as Mock).mock.calls[0][0]
+      .handler;
+    const updatedComment: Comment = {
+      id: "1",
+      content: "Updated comment",
+      hostId: "1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+    };
+    const event = { subject: "comment-1", data: updatedComment };
+
+    eventHandler(event);
+
+    expect(mockCacheStore.set).toHaveBeenCalledWith("1", [
+      updatedComment,
+      {
+        id: "2",
+        content: "Another comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+    ]);
+  });
+});

--- a/src/app/policies/whenever-comment-created-invalidate-cache.ts
+++ b/src/app/policies/whenever-comment-created-invalidate-cache.ts
@@ -1,0 +1,35 @@
+import type { Comment } from "../domain/entities/comment.js";
+import type { CacheStore } from "../driven-ports/cache-store.js";
+import type { EventBroker } from "../driven-ports/event-broker.js";
+
+type WheneverCommentCreatedInvalidateCachePolicy = ({
+  eventBroker,
+  cacheStore,
+}: {
+  eventBroker: EventBroker;
+  cacheStore: CacheStore;
+}) => void;
+
+const wheneverCommentCreatedInvalidateCache: WheneverCommentCreatedInvalidateCachePolicy =
+  ({ eventBroker, cacheStore }) => {
+    eventBroker.subscribe({
+      type: "kommentar.comment.created",
+      handler: (event) => {
+        const key = event.subject;
+
+        const currentCachedComments = cacheStore.get(key) as
+          | Comment[]
+          | undefined;
+
+        const newComment = event.data as Comment;
+
+        if (!currentCachedComments) {
+          cacheStore.set(key, [newComment]);
+        } else {
+          cacheStore.set(key, [...currentCachedComments, newComment]);
+        }
+      },
+    });
+  };
+
+export { wheneverCommentCreatedInvalidateCache };

--- a/src/app/policies/whenever-comment-deleted-invalidate-cache.ts
+++ b/src/app/policies/whenever-comment-deleted-invalidate-cache.ts
@@ -1,0 +1,38 @@
+import type { Comment } from "../domain/entities/comment.js";
+import type { CacheStore } from "../driven-ports/cache-store.js";
+import type { EventBroker } from "../driven-ports/event-broker.js";
+
+type WheneverCommentDeletedInvalidateCachePolicy = ({
+  eventBroker,
+  cacheStore,
+}: {
+  eventBroker: EventBroker;
+  cacheStore: CacheStore;
+}) => void;
+
+const wheneverCommentDeletedInvalidateCache: WheneverCommentDeletedInvalidateCachePolicy =
+  ({ eventBroker, cacheStore }) => {
+    eventBroker.subscribe({
+      type: "kommentar.comment.deleted",
+      handler: (event) => {
+        const deletedComment = event.data as Comment;
+        const { hostId: key } = deletedComment;
+
+        const currentCachedComments = cacheStore.get(key) as
+          | Comment[]
+          | undefined;
+
+        if (!currentCachedComments) {
+          return;
+        }
+
+        const updatedCachedComments = currentCachedComments.filter(
+          (comment) => comment.id !== deletedComment.id,
+        );
+
+        cacheStore.set(key, updatedCachedComments);
+      },
+    });
+  };
+
+export { wheneverCommentDeletedInvalidateCache };

--- a/src/app/policies/whenever-comment-updated-invalidate-cache.ts
+++ b/src/app/policies/whenever-comment-updated-invalidate-cache.ts
@@ -1,0 +1,38 @@
+import type { Comment } from "../domain/entities/comment.js";
+import type { CacheStore } from "../driven-ports/cache-store.js";
+import type { EventBroker } from "../driven-ports/event-broker.js";
+
+type WheneverCommentUpdatedInvalidateCachePolicy = ({
+  eventBroker,
+  cacheStore,
+}: {
+  eventBroker: EventBroker;
+  cacheStore: CacheStore;
+}) => void;
+
+const wheneverCommentUpdatedInvalidateCache: WheneverCommentUpdatedInvalidateCachePolicy =
+  ({ eventBroker, cacheStore }) => {
+    eventBroker.subscribe({
+      type: "kommentar.comment.updated",
+      handler: (event) => {
+        const updatedComment = event.data as Comment;
+        const { hostId: key } = updatedComment;
+
+        const currentCachedComments = cacheStore.get(key) as
+          | Comment[]
+          | undefined;
+
+        if (!currentCachedComments) {
+          cacheStore.set(key, [updatedComment]);
+        } else {
+          const updatedCachedComments = currentCachedComments.map((comment) =>
+            comment.id === updatedComment.id ? updatedComment : comment,
+          );
+
+          cacheStore.set(key, updatedCachedComments);
+        }
+      },
+    });
+  };
+
+export { wheneverCommentUpdatedInvalidateCache };

--- a/src/app/queries/__tests__/get-comments-for-host.unit.test.ts
+++ b/src/app/queries/__tests__/get-comments-for-host.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DataStore } from "../../driven-ports/data-store.js";
+import { queryGetCommentsForHost } from "../get-comments-for-host/index.js";
+
+describe("queryGetCommentsForHost", () => {
+  it("should return an empty array when there are no comments for the given host ID", async () => {
+    const mockDataStore: DataStore = {
+      getAllCommentsByHostId: vi.fn().mockResolvedValue([]),
+      deleteCommentById: vi.fn(),
+      saveCommentByHostId: vi.fn(),
+      updateCommentById: vi.fn(),
+    };
+
+    const getCommentsForHost = queryGetCommentsForHost(mockDataStore);
+    const comments = await getCommentsForHost({ hostId: "1" });
+
+    expect(comments).toEqual([]);
+    expect(mockDataStore.getAllCommentsByHostId).toHaveBeenCalledWith({
+      hostId: "1",
+    });
+  });
+
+  it("should return an array of comments for the given host ID", async () => {
+    const savedComments = [
+      {
+        id: "1",
+        content: "First comment",
+        hostid: "1",
+        createdat: new Date("2021-01-01"),
+        updatedat: new Date("2021-01-01"),
+      },
+      {
+        id: "2",
+        content: "Second comment",
+        hostid: "1",
+        createdat: new Date("2021-01-02"),
+        updatedat: new Date("2021-01-02"),
+      },
+    ];
+
+    const mockDataStore: DataStore = {
+      getAllCommentsByHostId: vi.fn().mockResolvedValue(savedComments),
+      deleteCommentById: vi.fn(),
+      saveCommentByHostId: vi.fn(),
+      updateCommentById: vi.fn(),
+    };
+
+    const getCommentsForHost = queryGetCommentsForHost(mockDataStore);
+    const comments = await getCommentsForHost({ hostId: "1" });
+
+    expect(comments).toEqual([
+      {
+        id: "1",
+        content: "First comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      },
+      {
+        id: "2",
+        content: "Second comment",
+        hostId: "1",
+        createdAt: new Date("2021-01-02"),
+        updatedAt: new Date("2021-01-02"),
+      },
+    ]);
+    expect(mockDataStore.getAllCommentsByHostId).toHaveBeenCalledWith({
+      hostId: "1",
+    });
+  });
+});

--- a/src/app/queries/get-comments-for-host/index.ts
+++ b/src/app/queries/get-comments-for-host/index.ts
@@ -7,9 +7,17 @@ type QueryGetCommentsForHost = (
 
 const queryGetCommentsForHost: QueryGetCommentsForHost = (dataStore) => {
   return async ({ hostId }) => {
-    const comment = await dataStore.getAllCommentsByHostId({ hostId });
+    const savedComments = await dataStore.getAllCommentsByHostId({ hostId });
 
-    return comment;
+    const comments: Comment[] = savedComments.map((comment) => ({
+      id: comment.id,
+      content: comment.content,
+      hostId: comment.hostid,
+      createdAt: comment.createdat,
+      updatedAt: comment.updatedat,
+    }));
+
+    return comments;
   };
 };
 

--- a/src/driven-adapters/cache-store/__tests__/in-memory.unit.test.ts
+++ b/src/driven-adapters/cache-store/__tests__/in-memory.unit.test.ts
@@ -1,0 +1,8 @@
+import { describe } from "vitest";
+import { getCacheStoreInMemory } from "../in-memory/index.js";
+import { runCacheStoreTests } from "../../../app/driven-ports/__tests__/cache-store.unit.test-runner.js";
+
+describe("DataStoreInMemory", () => {
+  const cacheStore = getCacheStoreInMemory();
+  runCacheStoreTests(cacheStore);
+});

--- a/src/driven-adapters/cache-store/in-memory/index.ts
+++ b/src/driven-adapters/cache-store/in-memory/index.ts
@@ -1,0 +1,24 @@
+import type { CacheStore } from "../../../app/driven-ports/cache-store.js";
+
+type GetCacheStoreInMemory = () => CacheStore;
+
+const getCacheStoreInMemory: GetCacheStoreInMemory = () => {
+  const cache: Record<string, unknown> = {};
+
+  return {
+    get: (key: string) => cache[key] ?? undefined,
+    set: (key: string, value: unknown) => {
+      cache[key] = value;
+    },
+    remove: (key: string) => {
+      delete cache[key];
+    },
+    clear: () => {
+      for (const key in cache) {
+        delete cache[key];
+      }
+    },
+  };
+};
+
+export { getCacheStoreInMemory };

--- a/src/driven-adapters/data-store/__tests__/in-memory.unit.test.ts
+++ b/src/driven-adapters/data-store/__tests__/in-memory.unit.test.ts
@@ -1,0 +1,8 @@
+import { describe } from "vitest";
+import { getDataStoreInMemory } from "../in-memory/index.js";
+import { runDataStoreTests } from "../../../app/driven-ports/__tests__/data-store.unit.test-runner.js";
+
+describe("DataStoreInMemory", () => {
+  const dataStore = getDataStoreInMemory();
+  runDataStoreTests(dataStore);
+});

--- a/src/driven-adapters/data-store/in-memory/__tests__/in-memory.unit.test.ts
+++ b/src/driven-adapters/data-store/in-memory/__tests__/in-memory.unit.test.ts
@@ -1,8 +1,0 @@
-import { describe } from "vitest";
-import { runDataStoreTests } from "../../../../app/driven-ports/__tests__/data-store.unit.test-runner.js";
-import { getDataStoreInMemory } from "../index.js";
-
-describe("DataStoreInMemory", () => {
-  const dataStore = getDataStoreInMemory();
-  runDataStoreTests(dataStore);
-});

--- a/src/driven-adapters/data-store/in-memory/index.ts
+++ b/src/driven-adapters/data-store/in-memory/index.ts
@@ -1,31 +1,33 @@
-import type { Comment } from "../../../app/domain/entities/comment.js";
-import type { DataStore } from "../../../app/driven-ports/data-store.js";
+import type {
+  DataStore,
+  StoredComment,
+} from "../../../app/driven-ports/data-store.js";
 
 type GetDataStoreInMemory = () => DataStore;
 
 const getDataStoreInMemory: GetDataStoreInMemory = () => {
-  const comments = new Map<string, Comment>();
+  const comments = new Map<string, StoredComment>();
   comments.set("1", {
     id: "1",
-    hostId: "1",
+    hostid: "1",
     content: "Hello, World! This is a sample comment.",
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdat: new Date(),
+    updatedat: new Date(),
   });
 
   return {
     async getAllCommentsByHostId({ hostId }) {
       return Array.from(comments.values()).filter(
-        (comment) => comment.hostId === hostId,
+        (comment) => comment.hostid === hostId,
       );
     },
     async saveCommentByHostId({ hostId, content }) {
-      const comment: Comment = {
+      const comment: StoredComment = {
         id: Math.random().toString(36).slice(2),
-        hostId,
+        hostid: hostId,
         content,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdat: new Date(),
+        updatedat: new Date(),
       };
       comments.set(comment.id, comment);
       return comment;
@@ -40,7 +42,12 @@ const getDataStoreInMemory: GetDataStoreInMemory = () => {
       return updatedComment;
     },
     async deleteCommentById({ id }) {
+      const comment = comments.get(id);
+      if (!comment) {
+        throw new Error(`Comment with id ${id} not found`);
+      }
       comments.delete(id);
+      return comment;
     },
   };
 };

--- a/src/driven-adapters/data-store/postgres/index.ts
+++ b/src/driven-adapters/data-store/postgres/index.ts
@@ -70,7 +70,9 @@ const getDataStorePostgres: GetDataStorePostgres = async ({
     },
     deleteCommentById: async ({ id }) => {
       try {
-        await pgPool.query(deleteCommentByIdQuery({ id }));
+        const result = await pgPool.query(deleteCommentByIdQuery({ id }));
+
+        return result.rows[0];
       } catch (error) {
         console.error("Failed to delete comment by identifier", error);
         throw error;

--- a/src/driven-adapters/data-store/postgres/queries.ts
+++ b/src/driven-adapters/data-store/postgres/queries.ts
@@ -86,7 +86,8 @@ const deleteCommentByIdQuery: DeleteCommentByIdQuery = ({ id }) => {
     name: "delete-comment-by-id",
     text: `
         DELETE FROM comments
-        WHERE id = $1;
+        WHERE id = $1
+        RETURNING *;
         `,
     values: [id],
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 import { getApp } from "./app/index.js";
+import { wheneverCommentCreatedInvalidateCache } from "./app/policies/whenever-comment-created-invalidate-cache.js";
+import { wheneverCommentDeletedInvalidateCache } from "./app/policies/whenever-comment-deleted-invalidate-cache.js";
+import { wheneverCommentUpdatedInvalidateCache } from "./app/policies/whenever-comment-updated-invalidate-cache.js";
+import { getCacheStoreInMemory } from "./driven-adapters/cache-store/in-memory/index.js";
 import { getConfigStaticEnv } from "./driven-adapters/config/static-env/index.js";
 import { getDataStorePostgres } from "./driven-adapters/data-store/postgres/index.js";
 import { getEventBrokerInMemory } from "./driven-adapters/event-broker/in-memory.js";
@@ -10,6 +14,7 @@ const config = getConfigStaticEnv();
 const secretStore = getSecretStoreEnv();
 const eventBroker = getEventBrokerInMemory();
 const randomId = getRandomIdUuid();
+const cacheStore = getCacheStoreInMemory();
 
 const dataStore = await getDataStorePostgres({
   config: config.dataStore,
@@ -17,7 +22,10 @@ const dataStore = await getDataStorePostgres({
   randomId,
 });
 
-const app = getApp({ dataStore, eventBroker, randomId });
+wheneverCommentCreatedInvalidateCache({ eventBroker, cacheStore });
+wheneverCommentUpdatedInvalidateCache({ eventBroker, cacheStore });
+wheneverCommentDeletedInvalidateCache({ eventBroker, cacheStore });
+const app = getApp({ dataStore, eventBroker, randomId, cacheStore });
 
 const hono = getHttpHono({ app, config: config.http });
 


### PR DESCRIPTION
- Commands publish events, since the state of the system changes
- Every event is subscribed to by policies
- Policies (event handlers) execute logic to invalidate cache as needed