### PR TITLE
Add commenter details to a Comment

### DIFF
--- a/src/app/commands/__tests__/create-comment.unit.test.ts
+++ b/src/app/commands/__tests__/create-comment.unit.test.ts
@@ -9,9 +9,10 @@ describe("commandCreateComment", () => {
         id: "1",
         content: "This is a comment",
         hostid: "host123",
-        createdat: new Date().toISOString(),
-        updatedat: new Date().toISOString(),
+        createdat: new Date("2021-01-01").toISOString(),
+        updatedat: new Date("2021-01-01").toISOString(),
         sessionid: "session1",
+        commenter_displayname: "John Doe",
       }),
       deleteCommentById: vi.fn(),
       getAllCommentsByHostId: vi.fn(),
@@ -25,6 +26,9 @@ describe("commandCreateComment", () => {
       hostId: "host123",
       content: "This is a comment",
       sessionId: "session1",
+      commenter: {
+        displayName: "John Doe",
+      },
     };
 
     const result = await createComment(input);
@@ -34,8 +38,11 @@ describe("commandCreateComment", () => {
       id: "1",
       hostId: "host123",
       content: "This is a comment",
-      createdAt: expect.any(String),
-      updatedAt: expect.any(String),
+      createdAt: "2021-01-01T00:00:00.000Z",
+      updatedAt: "2021-01-01T00:00:00.000Z",
+      commenter: {
+        displayName: "John Doe",
+      },
     });
   });
 });

--- a/src/app/commands/__tests__/delete-comment.unit.test.ts
+++ b/src/app/commands/__tests__/delete-comment.unit.test.ts
@@ -9,9 +9,12 @@ describe("commandDeleteComment", () => {
       id: "1",
       content: "Test comment",
       hostId: "host1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
       sessionId: "session1",
+      commenter: {
+        displayName: "John Doe",
+      },
     };
 
     const mockDataStore: DataStore = {
@@ -22,6 +25,7 @@ describe("commandDeleteComment", () => {
         createdat: mockComment.createdAt,
         updatedat: mockComment.updatedAt,
         sessionid: mockComment.sessionId,
+        commenter_displayname: mockComment.commenter.displayName,
       }),
       getCommentById: vi.fn().mockResolvedValue({
         id: mockComment.id,
@@ -30,6 +34,7 @@ describe("commandDeleteComment", () => {
         createdat: mockComment.createdAt,
         updatedat: mockComment.updatedAt,
         sessionid: mockComment.sessionId,
+        commenter_displayname: mockComment.commenter.displayName,
       }),
       getAllCommentsByHostId: vi.fn(),
       saveCommentByHostId: vi.fn(),
@@ -80,6 +85,9 @@ describe("commandDeleteComment", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       sessionId: "session1",
+      commenter: {
+        displayName: "John Doe",
+      },
     };
 
     const mockDataStore: DataStore = {

--- a/src/app/commands/__tests__/update-comment.unit.test.ts
+++ b/src/app/commands/__tests__/update-comment.unit.test.ts
@@ -9,14 +9,19 @@ describe("commandUpdateComment", () => {
         id: "1",
         content: "Updated content",
         sessionid: "session1",
+        hostid: "host1",
+        createdat: new Date("2021-01-01"),
+        updatedat: new Date("2021-01-01"),
+        commenter_displayname: "John Doe",
       }),
       getCommentById: vi.fn().mockResolvedValue({
         id: "1",
         content: "Test comment",
         hostId: "host1",
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
         sessionid: "session1",
+        commenter_displayname: "John Doe",
       }),
       deleteCommentById: vi.fn(),
       getAllCommentsByHostId: vi.fn(),
@@ -37,6 +42,12 @@ describe("commandUpdateComment", () => {
     expect(result).toEqual({
       id: "1",
       content: "Updated content",
+      hostId: "host1",
+      createdAt: new Date("2021-01-01"),
+      updatedAt: new Date("2021-01-01"),
+      commenter: {
+        displayName: "John Doe",
+      },
     });
   });
 

--- a/src/app/commands/create-comment/index.ts
+++ b/src/app/commands/create-comment/index.ts
@@ -7,18 +7,21 @@ type CommandCreateComment = (
   hostId,
   content,
   sessionId,
+  commenter,
 }: {
   hostId: Comment["hostId"];
   content: Comment["content"];
   sessionId: Comment["sessionId"];
+  commenter: Comment["commenter"];
 }) => Promise<PublicComment>;
 
 const commandCreateComment: CommandCreateComment = (dataStore) => {
-  return async ({ hostId, content, sessionId }) => {
+  return async ({ hostId, content, sessionId, commenter }) => {
     const savedComment = await dataStore.saveCommentByHostId({
       hostId,
       content,
       sessionId,
+      commenter,
     });
 
     return {
@@ -27,6 +30,10 @@ const commandCreateComment: CommandCreateComment = (dataStore) => {
       hostId: savedComment.hostid,
       createdAt: savedComment.createdat,
       updatedAt: savedComment.updatedat,
+      commenter: {
+        displayName: savedComment.commenter_displayname,
+        realName: savedComment.commenter_realname,
+      },
     };
   };
 };

--- a/src/app/commands/delete-comment/index.ts
+++ b/src/app/commands/delete-comment/index.ts
@@ -41,6 +41,10 @@ const commandDeleteComment: CommandDeleteComment = (dataStore) => {
       createdAt: deletedComment.createdat,
       updatedAt: deletedComment.updatedat,
       sessionId: deletedComment.sessionid,
+      commenter: {
+        displayName: deletedComment.commenter_displayname,
+        realName: deletedComment.commenter_realname,
+      },
     };
   };
 };

--- a/src/app/commands/update-comment/index.ts
+++ b/src/app/commands/update-comment/index.ts
@@ -46,6 +46,10 @@ const commandUpdateComment: CommandUpdateComment = (dataStore) => {
       hostId: updatedComment.hostid,
       createdAt: updatedComment.createdat,
       updatedAt: updatedComment.updatedat,
+      commenter: {
+        displayName: updatedComment.commenter_displayname,
+        realName: updatedComment.commenter_realname,
+      },
     };
   };
 };

--- a/src/app/domain/entities/app.ts
+++ b/src/app/domain/entities/app.ts
@@ -10,10 +10,15 @@ type App = {
     hostId,
     content,
     sessionId,
+    commenter,
   }: {
     hostId: string;
     content: string;
     sessionId: string;
+    commenter: {
+      displayName: string;
+      realName?: string;
+    };
   }) => Promise<PublicComment>;
   updateCommentById: ({
     id,

--- a/src/app/domain/entities/comment.ts
+++ b/src/app/domain/entities/comment.ts
@@ -1,3 +1,17 @@
+type Commenter = {
+  /**
+   * Display name of the commenter
+   * @example "safwanyp"
+   */
+  displayName: string;
+  /**
+   *
+   * Real name of the commenter
+   * @example "Safwan Parkar"
+   */
+  realName?: string;
+};
+
 type Comment = {
   /**
    * Unique identifier of the comment
@@ -23,6 +37,10 @@ type Comment = {
    * Unique identifier of the session
    */
   sessionId: string;
+  /**
+   * Commenter details
+   */
+  commenter: Commenter;
 };
 
 type PublicComment = Omit<Comment, "sessionId">;

--- a/src/app/driven-ports/data-store.ts
+++ b/src/app/driven-ports/data-store.ts
@@ -7,6 +7,8 @@ type StoredComment = {
   createdat: Comment["createdAt"];
   updatedat: Comment["updatedAt"];
   sessionid: Comment["sessionId"];
+  commenter_displayname: Comment["commenter"]["displayName"];
+  commenter_realname?: Comment["commenter"]["realName"];
 };
 
 type DataStore = {
@@ -27,16 +29,20 @@ type DataStore = {
    *
    * @param hostId - Unique identifier of the host, where the comment is placed
    * @param content - Content of the comment
+   * @param sessionId - Unique identifier of the session
+   * @param commenter - Commenter information
    * @returns The saved comment
    */
   saveCommentByHostId: ({
     hostId,
     content,
     sessionId,
+    commenter,
   }: {
     hostId: Comment["hostId"];
     content: Comment["content"];
     sessionId: Comment["sessionId"];
+    commenter: Comment["commenter"];
   }) => Promise<StoredComment>;
 
   /**

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -53,7 +53,7 @@ const getApp: GetApp = ({
 
       return comments;
     },
-    createCommentForHost: async ({ hostId, content, sessionId }) => {
+    createCommentForHost: async ({ hostId, content, sessionId, commenter }) => {
       const isProfane = await profanityClient.check(content);
 
       if (isProfane === "PROFANE") {
@@ -70,6 +70,7 @@ const getApp: GetApp = ({
         hostId,
         content,
         sessionId,
+        commenter,
       });
 
       const event = toCommentCreatedEvent({

--- a/src/app/queries/__tests__/get-comments-for-host.unit.test.ts
+++ b/src/app/queries/__tests__/get-comments-for-host.unit.test.ts
@@ -9,6 +9,7 @@ describe("queryGetCommentsForHost", () => {
       deleteCommentById: vi.fn(),
       saveCommentByHostId: vi.fn(),
       updateCommentById: vi.fn(),
+      getCommentById: vi.fn(),
     };
 
     const getCommentsForHost = queryGetCommentsForHost(mockDataStore);
@@ -28,6 +29,7 @@ describe("queryGetCommentsForHost", () => {
         hostid: "1",
         createdat: new Date("2021-01-01"),
         updatedat: new Date("2021-01-01"),
+        commenter_displayname: "John Doe",
       },
       {
         id: "2",
@@ -35,6 +37,7 @@ describe("queryGetCommentsForHost", () => {
         hostid: "1",
         createdat: new Date("2021-01-02"),
         updatedat: new Date("2021-01-02"),
+        commenter_displayname: "Jane Doe",
       },
     ];
 
@@ -43,6 +46,7 @@ describe("queryGetCommentsForHost", () => {
       deleteCommentById: vi.fn(),
       saveCommentByHostId: vi.fn(),
       updateCommentById: vi.fn(),
+      getCommentById: vi.fn(),
     };
 
     const getCommentsForHost = queryGetCommentsForHost(mockDataStore);
@@ -55,6 +59,9 @@ describe("queryGetCommentsForHost", () => {
         hostId: "1",
         createdAt: new Date("2021-01-01"),
         updatedAt: new Date("2021-01-01"),
+        commenter: {
+          displayName: "John Doe",
+        },
       },
       {
         id: "2",
@@ -62,6 +69,9 @@ describe("queryGetCommentsForHost", () => {
         hostId: "1",
         createdAt: new Date("2021-01-02"),
         updatedAt: new Date("2021-01-02"),
+        commenter: {
+          displayName: "Jane Doe",
+        },
       },
     ]);
     expect(mockDataStore.getAllCommentsByHostId).toHaveBeenCalledWith({

--- a/src/app/queries/get-comments-for-host/index.ts
+++ b/src/app/queries/get-comments-for-host/index.ts
@@ -15,6 +15,10 @@ const queryGetCommentsForHost: QueryGetCommentsForHost = (dataStore) => {
       hostId: comment.hostid,
       createdAt: comment.createdat,
       updatedAt: comment.updatedat,
+      commenter: {
+        displayName: comment.commenter_displayname,
+        realName: comment.commenter_realname,
+      },
     }));
   };
 };

--- a/src/driven-adapters/data-store/postgres/index.ts
+++ b/src/driven-adapters/data-store/postgres/index.ts
@@ -44,11 +44,17 @@ const getDataStorePostgres: GetDataStorePostgres = async ({
         throw error;
       }
     },
-    saveCommentByHostId: async ({ hostId, content, sessionId }) => {
+    saveCommentByHostId: async ({ hostId, content, sessionId, commenter }) => {
       try {
         const id = randomId.generate();
         const result = await pgPool.query(
-          saveCommentByHostIdQuery({ id, hostId, content, sessionId }),
+          saveCommentByHostIdQuery({
+            id,
+            hostId,
+            content,
+            sessionId,
+            commenter,
+          }),
         );
 
         return result.rows[0];

--- a/src/driven-adapters/data-store/postgres/migrate.ts
+++ b/src/driven-adapters/data-store/postgres/migrate.ts
@@ -35,6 +35,20 @@ const queries: Queries = {
       ADD COLUMN IF NOT EXISTS sessionId uuid NOT NULL;
     `,
   },
+  sessionIdIndex: {
+    name: "create-table-comments-index-session-id",
+    text: `
+      CREATE INDEX IF NOT EXISTS comments_session_id_idx ON comments (sessionId);
+    `,
+  },
+  addCommenterColumns: {
+    name: "add-commenter-columns",
+    text: `
+        ALTER TABLE comments
+        ADD COLUMN IF NOT EXISTS commenter_displayname text NOT NULL DEFAULT 'Anonymous',
+        ADD COLUMN IF NOT EXISTS commenter_realname text;
+      `,
+  },
 };
 
 const migrate: Migrate = async ({ pgPool }) => {
@@ -48,6 +62,8 @@ const migrate: Migrate = async ({ pgPool }) => {
     await client.query(queries.createTableCommentsIndexHostId);
     await client.query(queries.createTableCommentsIndexCreatedAt);
     await client.query(queries.addSessionIdColumn);
+    await client.query(queries.sessionIdIndex);
+    await client.query(queries.addCommenterColumns);
     await client.query("COMMIT");
 
     console.debug("Database migration completed");

--- a/src/driven-adapters/data-store/postgres/migrate.ts
+++ b/src/driven-adapters/data-store/postgres/migrate.ts
@@ -55,7 +55,7 @@ const migrate: Migrate = async ({ pgPool }) => {
   const client = await pgPool.connect();
 
   try {
-    console.debug("Starting database migration", queries);
+    console.debug("Starting database migration");
 
     await client.query("BEGIN");
     await client.query(queries.createTableComments);

--- a/src/driven-adapters/data-store/postgres/queries.ts
+++ b/src/driven-adapters/data-store/postgres/queries.ts
@@ -11,11 +11,13 @@ type SaveCommentByHostIdQuery = ({
   hostId,
   content,
   sessionId,
+  commenter,
 }: {
   id: Comment["id"];
   hostId: Comment["hostId"];
   content: Comment["content"];
   sessionId: Comment["sessionId"];
+  commenter: Comment["commenter"];
 }) => QueryConfig;
 type UpdateCommentByIdQuery = ({
   id,
@@ -52,15 +54,23 @@ const saveCommentByHostIdQuery: SaveCommentByHostIdQuery = ({
   hostId,
   content,
   sessionId,
+  commenter,
 }) => {
   return {
     name: "save-comment-by-host-id",
     text: `
-        INSERT INTO comments (id, content, hostId, createdAt, updatedAt, sessionId)
-        VALUES ($1, $2, $3, NOW(), NOW(), $4)
+        INSERT INTO comments (id, content, hostId, createdAt, updatedAt, sessionId, commenter_displayname, commenter_realname)
+        VALUES ($1, $2, $3, NOW(), NOW(), $4, $5, $6)
         RETURNING *;
         `,
-    values: [id, content, hostId, sessionId],
+    values: [
+      id,
+      content,
+      hostId,
+      sessionId,
+      commenter.displayName,
+      commenter.realName,
+    ],
   };
 };
 

--- a/src/driver-adapters/http/hono-zod-openapi/app.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/app.ts
@@ -39,13 +39,14 @@ const getHttpAppHonoZodOpenApi: GetHttpAppHonoZodOpenApi = ({
 
   hono.openapi(createCommentForHostRoute, async (c) => {
     const { hostId } = c.req.valid("param");
-    const { content } = c.req.valid("json");
+    const { content, commenter } = c.req.valid("json");
     const sessionId = getCookie(c, "sessionId") as string;
 
     const comment = await app.createCommentForHost({
       hostId,
       content,
       sessionId,
+      commenter,
     });
 
     return c.json(comment, 201);

--- a/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
@@ -23,6 +23,20 @@ const commentSchema = z
       description: "Date when the comment was last updated",
       example: "2024-11-01T12:00:00.000Z",
     }),
+    commenter: z
+      .object({
+        displayName: z.string().openapi({
+          description: "Display name of the commenter",
+          example: "safwanyp",
+        }),
+        realName: z.string().optional().openapi({
+          description: "Real name of the commenter",
+          example: "Safwan Parkar",
+        }),
+      })
+      .openapi({
+        description: "Information about the commenter",
+      }),
   })
   .openapi("Comment");
 
@@ -91,6 +105,21 @@ const PostCommentByHostIdSchema = {
       content: z.string().openapi({
         example: "This is a comment",
       }),
+      commenter: z
+        .object({
+          displayName: z.string().openapi({
+            example: "safwanyp",
+          }),
+          realName: z.string().optional().openapi({
+            example: "Safwan Parkar",
+          }),
+        })
+        .openapi({
+          example: {
+            displayName: "safwanyp",
+            realName: "Safwan Parkar",
+          },
+        }),
     })
     .required(),
   response: commentSchema,


### PR DESCRIPTION
Add a `commenter` property to the Comment entity.

`commenter` is a stateless property, meaning that it can be anything and doesn't affect the actual comment. That being said, a `displayName` is required to have something as an identifier (without actually being an identifier) and the `realName` is optional. 