### PR TITLE
Move all routes under /api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm run test:unit && pnpm run test:integration && vitest run --coverage",
     "test:watch": "vitest",
     "manage": "node dist/scripts/manage-consumers.js",
-    "manage:dev": "tsx --env-file=.env scripts/manage-consumers.ts",
+    "manage:dev": "tsx --env-file=.env src/scripts/manage-consumers.ts",
     "manage:test-consumer": "tsx --env-file=.env scripts/create-test-consumer.ts",
     "manage:test-api": "tsx --env-file=.env scripts/test-api-client.ts"
   },

--- a/src/driver-adapters/http/hono-zod-openapi/app.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/app.ts
@@ -1,28 +1,11 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import type { App } from "../../../app/domain/entities/app.js";
-import {
-  createCommentForHostRoute,
-  deleteCommentByIdRoute,
-  getCommentsForHostRoute,
-  getConsumerByIdRoute,
-  updateCommentByIdRoute,
-} from "./routes.js";
 import { Scalar } from "@scalar/hono-api-reference";
 import { HTTPException } from "hono/http-exception";
-import { getCookie } from "hono/cookie";
 import type { RandomId } from "../../../app/driven-ports/random-id.js";
-import {
-  consumerAuthMiddleware,
-  consumerRateLimitMiddleware,
-  rateLimitMiddleware,
-  sessionMiddleware,
-} from "./middlewares.js";
+import { rateLimitMiddleware, sessionMiddleware } from "./middlewares.js";
 import type { DataStore } from "../../../app/driven-ports/data-store.js";
-import { createHttpError } from "./helpers.js";
-import {
-  errors,
-  type CustomError,
-} from "../../../app/domain/entities/error.js";
+import { getRouter } from "./router/index.js";
 
 type GetHttpAppHonoZodOpenApi = ({
   app,
@@ -58,89 +41,10 @@ const getHttpAppHonoZodOpenApi: GetHttpAppHonoZodOpenApi = ({
 
   const hono = new OpenAPIHono();
 
+  const { apiRouter } = getRouter({ app, dataStore });
+
   hono.use(sessionMiddleware(randomId));
   hono.use(rateLimitMiddleware);
-
-  hono.use("/hosts/*", consumerAuthMiddleware(dataStore));
-  hono.use("/hosts/*", consumerRateLimitMiddleware());
-
-  hono.use("/consumers/*", consumerAuthMiddleware(dataStore));
-
-  // Comment routes
-  hono.openapi(getCommentsForHostRoute, async (c) => {
-    try {
-      const { hostId } = c.req.valid("param");
-
-      const comments = await app.getCommentsForHost({ hostId });
-
-      return c.json(comments, 200);
-    } catch (err) {
-      throw createHttpError(err as unknown as CustomError);
-    }
-  });
-
-  hono.openapi(createCommentForHostRoute, async (c) => {
-    try {
-      const { hostId } = c.req.valid("param");
-      const { content, commenter } = c.req.valid("json");
-      const sessionId = getCookie(c, "sessionId") as string;
-
-      const comment = await app.createCommentForHost({
-        hostId,
-        content,
-        sessionId,
-        commenter,
-      });
-
-      return c.json(comment, 201);
-    } catch (err) {
-      throw createHttpError(err as unknown as CustomError);
-    }
-  });
-
-  hono.openapi(updateCommentByIdRoute, async (c) => {
-    try {
-      const { id } = c.req.valid("param");
-      const { content } = c.req.valid("json");
-      const sessionId = getCookie(c, "sessionId") as string;
-
-      const comment = await app.updateCommentById({ id, content, sessionId });
-
-      return c.json(comment, 200);
-    } catch (err) {
-      throw createHttpError(err as unknown as CustomError);
-    }
-  });
-
-  hono.openapi(deleteCommentByIdRoute, async (c) => {
-    try {
-      const { id } = c.req.valid("param");
-      const sessionId = getCookie(c, "sessionId") as string;
-
-      await app.deleteCommentById({ id, sessionId });
-
-      return c.json({ message: "Comment deleted" }, 200);
-    } catch (err) {
-      throw createHttpError(err as unknown as CustomError);
-    }
-  });
-
-  // Consumer info route (read-only for self-inspection)
-  hono.openapi(getConsumerByIdRoute, async (c) => {
-    try {
-      const { id } = c.req.valid("param");
-
-      const consumer = await app.getConsumerById({ id });
-
-      if (!consumer) {
-        throw errors.domain.consumerNotFound;
-      }
-
-      return c.json(consumer, 200);
-    } catch (err) {
-      throw createHttpError(err as unknown as CustomError);
-    }
-  });
 
   // Documentation
   hono.doc("/spec", {
@@ -160,6 +64,8 @@ const getHttpAppHonoZodOpenApi: GetHttpAppHonoZodOpenApi = ({
       defaultOpenAllTags: true,
     }),
   );
+
+  hono.route("/", apiRouter);
 
   hono.onError((err, c) => {
     if (err instanceof HTTPException) {

--- a/src/driver-adapters/http/hono-zod-openapi/middlewares.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/middlewares.ts
@@ -95,8 +95,8 @@ const consumerAuthMiddleware: ConsumerAuthMiddleware = (dataStore) =>
         const allowedHosts = JSON.parse(consumer.allowedhosts) as string[];
         const requestPath = c.req.path;
 
-        // Extract hostId from the new URL structure: /hosts/{hostId}/...
-        const hostIdMatch = requestPath.match(/^\/hosts\/([^/]+)/);
+        // Extract hostId from the new URL structure: /api/hosts/{hostId}/...
+        const hostIdMatch = requestPath.match(/^\/api\/hosts\/([^/]+)/);
 
         if (hostIdMatch && allowedHosts.length > 0) {
           const requestedHostId = hostIdMatch[1];

--- a/src/driver-adapters/http/hono-zod-openapi/router/api.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/router/api.ts
@@ -1,0 +1,114 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import {
+  consumerAuthMiddleware,
+  consumerRateLimitMiddleware,
+} from "../middlewares.js";
+import type { DataStore } from "../../../../app/driven-ports/data-store.js";
+import {
+  createCommentForHostRoute,
+  deleteCommentByIdRoute,
+  getCommentsForHostRoute,
+  getConsumerByIdRoute,
+  updateCommentByIdRoute,
+} from "../routes.js";
+import type { App } from "../../../../app/domain/entities/app.js";
+import { createHttpError } from "../helpers.js";
+import {
+  errors,
+  type CustomError,
+} from "../../../../app/domain/entities/error.js";
+import { getCookie } from "hono/cookie";
+
+type GetApiRouter = ({
+  app,
+  dataStore,
+}: {
+  app: App;
+  dataStore: DataStore;
+}) => OpenAPIHono;
+
+const getApiRouter: GetApiRouter = ({ app, dataStore }) => {
+  const apiRouter = new OpenAPIHono();
+
+  apiRouter.use(consumerAuthMiddleware(dataStore));
+  apiRouter.use(consumerRateLimitMiddleware());
+
+  apiRouter.openapi(getCommentsForHostRoute, async (c) => {
+    try {
+      const { hostId } = c.req.valid("param");
+
+      const comments = await app.getCommentsForHost({ hostId });
+
+      return c.json(comments, 200);
+    } catch (err) {
+      throw createHttpError(err as unknown as CustomError);
+    }
+  });
+
+  apiRouter.openapi(createCommentForHostRoute, async (c) => {
+    try {
+      const { hostId } = c.req.valid("param");
+      const { content, commenter } = c.req.valid("json");
+      const sessionId = getCookie(c, "sessionId") as string;
+
+      const comment = await app.createCommentForHost({
+        hostId,
+        content,
+        sessionId,
+        commenter,
+      });
+
+      return c.json(comment, 201);
+    } catch (err) {
+      throw createHttpError(err as unknown as CustomError);
+    }
+  });
+
+  apiRouter.openapi(updateCommentByIdRoute, async (c) => {
+    try {
+      const { id } = c.req.valid("param");
+      const { content } = c.req.valid("json");
+      const sessionId = getCookie(c, "sessionId") as string;
+
+      const comment = await app.updateCommentById({ id, content, sessionId });
+
+      return c.json(comment, 200);
+    } catch (err) {
+      throw createHttpError(err as unknown as CustomError);
+    }
+  });
+
+  apiRouter.openapi(deleteCommentByIdRoute, async (c) => {
+    try {
+      const { id } = c.req.valid("param");
+      const sessionId = getCookie(c, "sessionId") as string;
+
+      await app.deleteCommentById({ id, sessionId });
+
+      return c.json({ message: "Comment deleted" }, 200);
+    } catch (err) {
+      throw createHttpError(err as unknown as CustomError);
+    }
+  });
+
+  // Consumer info route (read-only for self-inspection)
+  apiRouter.openapi(getConsumerByIdRoute, async (c) => {
+    try {
+      const { id } = c.req.valid("param");
+
+      const consumer = await app.getConsumerById({ id });
+
+      if (!consumer) {
+        throw errors.domain.consumerNotFound;
+      }
+
+      return c.json(consumer, 200);
+    } catch (err) {
+      throw createHttpError(err as unknown as CustomError);
+    }
+  });
+
+  return apiRouter;
+};
+
+export { getApiRouter };

--- a/src/driver-adapters/http/hono-zod-openapi/router/index.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/router/index.ts
@@ -1,0 +1,16 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { App } from "../../../../app/domain/entities/app.js";
+import type { DataStore } from "../../../../app/driven-ports/data-store.js";
+import { getApiRouter } from "./api.js";
+
+type GetRouter = ({ app, dataStore }: { app: App; dataStore: DataStore }) => {
+  apiRouter: OpenAPIHono;
+};
+
+const getRouter: GetRouter = ({ app, dataStore }) => {
+  const apiRouter = getApiRouter({ app, dataStore });
+
+  return { apiRouter };
+};
+
+export { getRouter };

--- a/src/driver-adapters/http/hono-zod-openapi/routes.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/routes.ts
@@ -14,7 +14,7 @@ const getCommentsForHostRoute = createRoute({
   description:
     "Retrieve all comments for a specific host. Requires API key and secret authentication.",
   method: "get",
-  path: "/hosts/{hostId}/comments",
+  path: "/api/hosts/{hostId}/comments",
   request: {
     params: GetCommentsByHostIdSchema.pathParams,
     headers: GetCommentsByHostIdSchema.headers,
@@ -47,7 +47,7 @@ const createCommentForHostRoute = createRoute({
   description:
     "Create a new comment for a specific host. Requires API key and secret authentication.",
   method: "post",
-  path: "/hosts/{hostId}/comments",
+  path: "/api/hosts/{hostId}/comments",
   request: {
     params: PostCommentByHostIdSchema.pathParams,
     headers: PostCommentByHostIdSchema.headers,
@@ -99,7 +99,7 @@ const updateCommentByIdRoute = createRoute({
   description:
     "Update an existing comment. Requires API key and secret authentication.",
   method: "put",
-  path: "/hosts/{hostId}/comments/{id}",
+  path: "/api/hosts/{hostId}/comments/{id}",
   request: {
     params: PutCommentByIdSchema.pathParams,
     headers: PutCommentByIdSchema.headers,
@@ -157,7 +157,7 @@ const deleteCommentByIdRoute = createRoute({
   description:
     "Delete an existing comment. Requires API key and secret authentication.",
   method: "delete",
-  path: "/hosts/{hostId}/comments/{id}",
+  path: "/api/hosts/{hostId}/comments/{id}",
   request: {
     params: DeleteCommentByIdSchema.pathParams,
     headers: DeleteCommentByIdSchema.headers,
@@ -202,7 +202,7 @@ const getConsumerByIdRoute = createRoute({
   description:
     "Retrieve consumer information by ID. Requires API key and secret authentication.",
   method: "get",
-  path: "/consumers/{id}",
+  path: "/api/consumers/{id}",
   request: {
     params: GetConsumerByIdSchema.pathParams,
     headers: GetConsumerByIdSchema.headers,
@@ -241,7 +241,7 @@ const createConsumerRoute = createRoute({
   description:
     "Create a new API consumer with generated credentials. Requires API key and secret authentication.",
   method: "post",
-  path: "/consumers",
+  path: "/api/consumers",
   request: {
     headers: PostConsumerSchema.headers,
     body: {


### PR DESCRIPTION
The reason for this change is to prepare for the introduction of another set of routes under `/api/super`. These new routes will be used for admin tooling.