### PR TITLE
Fix response types in the /super routes

### DIFF
--- a/src/app/domain/entities/app.ts
+++ b/src/app/domain/entities/app.ts
@@ -40,18 +40,11 @@ type CommentOperations = {
 };
 
 type ConsumerOperations = {
-  createConsumer: ({ consumer }: { consumer: Consumer }) => Promise<Consumer>;
-  deleteConsumer: ({ id }: { id: Consumer["id"] }) => Promise<PublicConsumer>;
   getConsumerById: ({
     id,
   }: {
     id: Consumer["id"];
   }) => Promise<PublicConsumer | undefined>;
-  updateConsumer: ({
-    consumer,
-  }: {
-    consumer: Consumer;
-  }) => Promise<PublicConsumer>;
   getFullConsumerById: ({
     id,
   }: {
@@ -63,7 +56,10 @@ type ConsumerOperations = {
   }: {
     offset: number;
     limit: number;
-  }) => Promise<PublicConsumer[]>;
+  }) => Promise<Consumer[]>;
+  createConsumer: ({ consumer }: { consumer: Consumer }) => Promise<Consumer>;
+  deleteConsumer: ({ id }: { id: Consumer["id"] }) => Promise<Consumer>;
+  updateConsumer: ({ consumer }: { consumer: Consumer }) => Promise<Consumer>;
 };
 
 type App = {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -205,7 +205,7 @@ const getApp: GetApp = ({
           consumerId: id,
         });
 
-        const mappedConsumer = toPublicConsumer(deletedConsumer);
+        const mappedConsumer = toConsumer(deletedConsumer);
 
         return mappedConsumer;
       },
@@ -223,7 +223,7 @@ const getApp: GetApp = ({
           consumer,
         });
 
-        const mappedConsumer = toPublicConsumer(updatedConsumer);
+        const mappedConsumer = toConsumer(updatedConsumer);
 
         return mappedConsumer;
       },
@@ -266,7 +266,7 @@ const getApp: GetApp = ({
           return [];
         }
 
-        const mappedConsumers = consumers.map(toPublicConsumer);
+        const mappedConsumers = consumers.map(toConsumer);
 
         return mappedConsumers;
       },

--- a/src/driver-adapters/http/hono-zod-openapi/router/super.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/router/super.ts
@@ -33,7 +33,7 @@ const getSuperRouter: GetSuperRouter = ({ app, secretStore }) => {
     try {
       const { id } = c.req.valid("param");
 
-      const consumer = await app.consumer.getConsumerById({ id });
+      const consumer = await app.consumer.getFullConsumerById({ id });
 
       if (!consumer) {
         throw errors.domain.consumerNotFound;

--- a/src/driver-adapters/http/hono-zod-openapi/router/super.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/router/super.ts
@@ -138,8 +138,8 @@ const getSuperRouter: GetSuperRouter = ({ app, secretStore }) => {
       const { offset, limit } = c.req.valid("query");
 
       const consumers = await app.consumer.getAllConsumers({
-        offset: offset ?? 0,
-        limit: limit ?? 100,
+        offset: !isNaN(Number(offset)) ? Number(offset) : 0,
+        limit: !isNaN(Number(limit)) ? Number(limit) : 100,
       });
 
       return c.json(consumers, 200);

--- a/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
@@ -42,6 +42,7 @@ const commentSchema = z
   })
   .openapi("Comment");
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const consumerSchema = z
   .object({
     id: z.string().openapi({
@@ -382,7 +383,7 @@ const GetConsumerByIdSchema = {
     })
     .required(),
   headers: superAuthHeaders,
-  response: consumerSchema,
+  response: consumerWithCredentialsSchema,
   errors: {
     400: genericErrorSchema,
     401: superCredentialsErrorSchema,
@@ -505,7 +506,7 @@ const PutConsumerSchema = {
       example: 100,
     }),
   }),
-  response: consumerSchema,
+  response: consumerWithCredentialsSchema,
   errors: {
     400: genericErrorSchema,
     401: superCredentialsErrorSchema,
@@ -527,7 +528,7 @@ const GetAllConsumersSchema = {
       example: 20,
     }),
   }),
-  response: z.array(consumerSchema).openapi("ConsumersList", {
+  response: z.array(consumerWithCredentialsSchema).openapi({
     description: "List of all consumers",
   }),
   errors: {

--- a/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
@@ -519,13 +519,13 @@ const PutConsumerSchema = {
 const GetAllConsumersSchema = {
   headers: superAuthHeaders,
   query: z.object({
-    offset: z.number().optional().openapi({
+    offset: z.string().optional().openapi({
       description: "Offset for pagination",
-      example: 0,
+      example: "0",
     }),
-    limit: z.number().optional().openapi({
+    limit: z.string().optional().openapi({
       description: "Limit for number of consumers to return",
-      example: 20,
+      example: "20",
     }),
   }),
   response: z.array(consumerWithCredentialsSchema).openapi({


### PR DESCRIPTION
I realized while building the admin console for Kommentar that the HTTP API does not return the "full" consumer in the `/super` routes. This was not intended. Since the `/super` routes are protected and can be accessed only by the admin, they should return all possible values and properties.

I might revisit this decision later, but I'm going to stick with it for now.

Another change I made was a fix for the zod types in `offset` and `limit`.