### PR TITLE
Implement health check

### DIFF
--- a/src/driver-adapters/http/hono-zod-openapi/app.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/app.ts
@@ -5,10 +5,12 @@ import type {
 import type { App } from "../../../app/domain/entities/app.js";
 import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono } from "@hono/zod-openapi";
+import type { ProfanityClient } from "../../../app/driven-ports/profanity-client.js";
 import type { RandomId } from "../../../app/driven-ports/random-id.js";
 import { Scalar } from "@scalar/hono-api-reference";
 import type { SecretStore } from "../../../app/driven-ports/secret-store.js";
 import { getRouter } from "./router/index.js";
+import { healthCheckRoute } from "./router/routes.js";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { sessionMiddleware } from "./middlewares.js";
 
@@ -23,12 +25,26 @@ type GetHttpAppHonoZodOpenApi = ({
   randomId,
   dataStore,
   secretStore,
+  profanityClient,
 }: {
   app: App;
   randomId: RandomId;
   dataStore: DataStore;
   secretStore: SecretStore;
+  profanityClient: ProfanityClient;
 }) => OpenAPIHono<CustomHonoEnv>;
+
+type HealthStatus = "healthy" | "unhealthy";
+type DataStoreTestHealthFn = (
+  dataStore: DataStore,
+) => Promise<{ status: HealthStatus; error?: string }>;
+type SecretStoreTestHealthFn = (
+  secretStore: SecretStore,
+) => Promise<{ status: HealthStatus; error?: string }>;
+type ProfanityClientTestHealthFn = (
+  profanityClient: ProfanityClient,
+) => Promise<{ status: HealthStatus; error?: string }>;
+type HealthObj = { overallStatus: HealthStatus };
 
 const apiClientservers = [
   {
@@ -37,11 +53,59 @@ const apiClientservers = [
   },
 ];
 
+const testDataStoreHealth: DataStoreTestHealthFn = async (dataStore) => {
+  try {
+    await dataStore.consumer.getCount();
+    return { status: "healthy" };
+  } catch (error) {
+    console.error("DataStore health check failed:", error);
+    return {
+      status: "unhealthy",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+const testSecretStoreHealth: SecretStoreTestHealthFn = async (secretStore) => {
+  try {
+    secretStore.get({ key: "__health_check__" });
+    return { status: "healthy" };
+  } catch (error) {
+    console.error("SecretStore health check failed:", error);
+    return {
+      status: "unhealthy",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
+const testProfanityClientHealth: ProfanityClientTestHealthFn = async (
+  profanityClient,
+) => {
+  try {
+    const foo = await profanityClient.check("this is not profane.");
+    const bar = await profanityClient.check("what a bunch of bullcrap");
+
+    if (foo === "CLEAN" && bar === "PROFANE") {
+      return { status: "healthy" };
+    }
+
+    return { status: "unhealthy" };
+  } catch (error) {
+    console.error("ProfanityClient health check failed:", error);
+    return {
+      status: "unhealthy",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+};
+
 const getHttpAppHonoZodOpenApi: GetHttpAppHonoZodOpenApi = ({
   app,
   randomId,
   dataStore,
   secretStore,
+  profanityClient,
 }) => {
   if (
     process.env.NODE_ENV === "production" &&
@@ -89,6 +153,42 @@ const getHttpAppHonoZodOpenApi: GetHttpAppHonoZodOpenApi = ({
 
   hono.route("/super", superRouter);
   hono.route("/api", apiRouter);
+
+  hono.openapi(healthCheckRoute, async (c) => {
+    const timestamp = new Date().toISOString();
+    const health: HealthObj = {
+      overallStatus: "healthy",
+    };
+
+    const dataStoreHealth = await testDataStoreHealth(dataStore);
+    if (dataStoreHealth.status === "unhealthy") {
+      health.overallStatus = "unhealthy";
+    }
+
+    const secretStoreHealth = await testSecretStoreHealth(secretStore);
+    if (secretStoreHealth.status === "unhealthy") {
+      health.overallStatus = "unhealthy";
+    }
+
+    const profanityClientHealth =
+      await testProfanityClientHealth(profanityClient);
+    if (profanityClientHealth.status === "unhealthy") {
+      health.overallStatus = "unhealthy";
+    }
+
+    const response = {
+      status: health.overallStatus,
+      timestamp,
+      dependencies: {
+        dataStore: dataStoreHealth,
+        secretStore: secretStoreHealth,
+        profanityClient: profanityClientHealth,
+      },
+    };
+
+    const statusCode = health.overallStatus === "healthy" ? 200 : 503;
+    return c.json(response, statusCode);
+  });
 
   hono.onError((err, c) => {
     if (err instanceof HTTPException) {

--- a/src/driver-adapters/http/hono-zod-openapi/index.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/index.ts
@@ -3,6 +3,7 @@ import type { App } from "../../../app/domain/entities/app.js";
 import type { Config } from "../../../app/driven-ports/config.js";
 import type { DataStore } from "../../../app/driven-ports/data-store.js";
 import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { ProfanityClient } from "../../../app/driven-ports/profanity-client.js";
 import type { RandomId } from "../../../app/driven-ports/random-id.js";
 import type { SecretStore } from "../../../app/driven-ports/secret-store.js";
 import type { ServerType } from "@hono/node-server";
@@ -14,12 +15,14 @@ type GetHttpHonoZodOpenApi = ({
   randomId,
   dataStore,
   secretStore,
+  profanityClient,
 }: {
   app: App;
   config: Config["http"];
   randomId: RandomId;
   dataStore: DataStore;
   secretStore: SecretStore;
+  profanityClient: ProfanityClient;
 }) => {
   app: OpenAPIHono<CustomHonoEnv>;
   server: ServerType;
@@ -31,12 +34,14 @@ const getHttpHonoZodOpenApi: GetHttpHonoZodOpenApi = ({
   randomId,
   dataStore,
   secretStore,
+  profanityClient,
 }) => {
   const httpApp = getHttpAppHonoZodOpenApi({
     app,
     randomId,
     dataStore,
     secretStore,
+    profanityClient,
   });
   const httpServer = getHonoZodOpenApiServer({
     app: httpApp,

--- a/src/driver-adapters/http/hono-zod-openapi/router/routes.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/router/routes.ts
@@ -4,6 +4,7 @@ import {
   GetAllConsumersSchema,
   GetCommentsByHostIdSchema,
   GetConsumerByIdSchema,
+  HealthCheckSchema,
   PostCommentByHostIdSchema,
   PostConsumerSchema,
   PutCommentByIdSchema,
@@ -460,6 +461,32 @@ const getAllConsumersRoute = createRoute({
   },
 });
 
+const healthCheckRoute = createRoute({
+  method: "get",
+  path: "/health",
+  tags: ["System"],
+  summary: "System health check",
+  description: "Checks the health of the API",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: HealthCheckSchema.response,
+        },
+      },
+      description: "Health check results",
+    },
+    503: {
+      content: {
+        "application/json": {
+          schema: HealthCheckSchema.response,
+        },
+      },
+      description: "Health check results",
+    },
+  },
+});
+
 export {
   getCommentsForHostRoute,
   createCommentForHostRoute,
@@ -470,4 +497,5 @@ export {
   deleteConsumerRoute,
   updateConsumerByIdRoute,
   getAllConsumersRoute,
+  healthCheckRoute,
 };

--- a/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
+++ b/src/driver-adapters/http/hono-zod-openapi/zod-schemas.ts
@@ -555,6 +555,39 @@ const GetAllConsumersSchema = {
   },
 };
 
+const HealthCheckSchema = {
+  response: z
+    .object({
+      status: z.enum(["healthy", "unhealthy"]).openapi({
+        description: "Overall health status",
+        example: "healthy",
+      }),
+      timestamp: z.string().openapi({
+        description: "ISO timestamp of the health check",
+        example: "2024-11-01T12:00:00.000Z",
+      }),
+      dependencies: z
+        .object({
+          dataStore: z.object({
+            status: z.enum(["healthy", "unhealthy"]),
+            error: z.string().optional(),
+          }),
+          secretStore: z.object({
+            status: z.enum(["healthy", "unhealthy"]),
+            error: z.string().optional(),
+          }),
+          profanityClient: z.object({
+            status: z.enum(["healthy", "unhealthy"]),
+            error: z.string().optional(),
+          }),
+        })
+        .openapi({
+          description: "Health status of each adapter",
+        }),
+    })
+    .openapi("HealthCheckResponse"),
+};
+
 export {
   GetCommentsByHostIdSchema,
   PostCommentByHostIdSchema,
@@ -565,4 +598,5 @@ export {
   DeleteConsumerByIdSchema,
   PutConsumerSchema,
   GetAllConsumersSchema,
+  HealthCheckSchema,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ const hono = getHttpHonoZodOpenApi({
   randomId,
   dataStore,
   secretStore,
+  profanityClient,
 });
 
 // * when running a dev server, tsx will force kill the process. (https://github.com/privatenumber/tsx/issues/586)


### PR DESCRIPTION
This PR adds a simple health check endpoint to the API. It is a simple route that does two things:
- Check if the data store is responding as expected
- Check if the secret store is responding as expected
- Check if the profanity checking tool is responding as expected

The other dependencies are all in-memory so I don't really need to worry about them.